### PR TITLE
Add support for vectors as bounds

### DIFF
--- a/src/automata.jl
+++ b/src/automata.jl
@@ -295,4 +295,5 @@ evol(a::Automaton, z_0, input) = evol_final(a, z_0, input)[1]
 
 Pad the state vector (or matrix of column vectors) `x` to as many dimensions as in the augmented state space of `a`.
 """
-augment(a::Automaton, x) = [x; zeros(a.nz - size(x, 1), size(x, 2))]
+augment(a::Automaton, x::AbstractMatrix) = [x; zeros(a.nz - size(x, 1), size(x, 2))]
+augment(a::Automaton, x::AbstractVector) = [x; zeros(a.nz - size(x, 1))]


### PR DESCRIPTION
Previously, we required that the initial set be given as a bounding box for all the major API functions.  This resulted in some inefficiency when the user only wanted a single initial state, in particular for the `bounded_runs` function.  This commit adds support for `bounds` being a vector instead of a matrix to alleviate this computational overhead.

Closes #4.