### PR TITLE
Implement JBF-based statistical deviation estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Tools for verifying safety of control systems that may experience timing
 uncertainty.
 
-This package, for the time being, consists primarily of an implementation of
-the Bounded Runs Iteration algorithm from the paper "Safety Analysis of
-Embedded Controllers under Implementation Platform Timing Uncertainties."  See
-the [Citing](#citing) section below for more information.
+This package provides tools for calculating safe overapproximations and
+probabilistic estimations of the maximum deviation a control system may suffer
+due to deadline misses.  If you find these tools useful in your research,
+please consider [citing](#citing) the papers that the algorithms originated in.
 
 ## Installation
 
@@ -54,11 +54,25 @@ notebook, `notebooks/control_timing_safety.jl`.
 ## Citing
 
 If you use this code in your research, we ask that you consider citing the
-relevant paper.  Currently, this means the following:
+relevant papers.  For the `bounded_runs_iter` function for overapproximating
+the maximum deviation, please cite:
 
-> Clara Hobbs, Bineet Ghosh, Shengjie Xu, Parasara Sridhar Duggirala, and Samarjit Chakraborty.
-> "Safety Analysis of Embedded Controllers under Implementation Platform Timing Uncertainties."
+> Clara Hobbs, Bineet Ghosh, Shengjie Xu, Parasara Sridhar Duggirala, and
+> Samarjit Chakraborty.
+> "Safety Analysis of Embedded Controllers under Implementation Platform Timing
+> Uncertainties."
 > TCAD 2022.
+> DOI: [10.1109/TCAD.2022.3198905](https://doi.org/10.1109/TCAD.2022.3198905)
+
+For the `estimate_deviation` function, based on Jeffreys' Bayes factor
+hypothesis testing, please cite:
+
+> Bineet Ghosh, Clara Hobbs, Shengjie Xu, Parasara Sridhar Duggirala, James H.
+> Anderson, P. S. Thiagarajan, and Samarjit Chakraborty.
+> "Statistical Hypothesis Testing of Controller Implementations Under Timing
+> Uncertainties."
+> RTCSA 2022.
+> DOI: [10.1109/RTCSA55878.2022.00008](https://doi.org/10.1109/RTCSA55878.2022.00008)
 
 As we continue this line of work, we intend to incorporate new algorithms in
 this package, and the list of papers will be updated accordingly (along with

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,10 +2,10 @@
 
 *Tools for verifying safety of control systems that may experience timing uncertainty*
 
-This package, for the time being, consists primarily of an implementation of
-the Bounded Runs Iteration algorithm from the paper "Safety Analysis of
-Embedded Controllers under Implementation Platform Timing Uncertainties."  See
-the [Citing](@ref) section below for more information.
+This package provides tools for calculating safe overapproximations and
+probabilistic estimations of the maximum deviation a control system may suffer
+due to deadline misses.  If you find these tools useful in your research,
+please consider [Citing](@ref) the papers that the algorithms originated in.
 
 ## Installation
 
@@ -50,11 +50,25 @@ notebook, `notebooks/control_timing_safety.jl`, included in the package.
 ## Citing
 
 If you use this code in your research, we ask that you consider citing the
-relevant paper.  Currently, this means the following:
+relevant papers.  For the [`bounded_runs_iter`](@ref) function for
+overapproximating the maximum deviation, please cite:
 
-> Clara Hobbs, Bineet Ghosh, Shengjie Xu, Parasara Sridhar Duggirala, and Samarjit Chakraborty.
-> "Safety Analysis of Embedded Controllers under Implementation Platform Timing Uncertainties."
+> Clara Hobbs, Bineet Ghosh, Shengjie Xu, Parasara Sridhar Duggirala, and
+> Samarjit Chakraborty.
+> "Safety Analysis of Embedded Controllers under Implementation Platform Timing
+> Uncertainties."
 > TCAD 2022.
+> DOI: [10.1109/TCAD.2022.3198905](https://doi.org/10.1109/TCAD.2022.3198905)
+
+For the [`estimate_deviation`](@ref) function, based on Jeffreys' Bayes factor
+hypothesis testing, please cite:
+
+> Bineet Ghosh, Clara Hobbs, Shengjie Xu, Parasara Sridhar Duggirala, James H.
+> Anderson, P. S. Thiagarajan, and Samarjit Chakraborty.
+> "Statistical Hypothesis Testing of Controller Implementations Under Timing
+> Uncertainties."
+> RTCSA 2022.
+> DOI: [10.1109/RTCSA55878.2022.00008](https://doi.org/10.1109/RTCSA55878.2022.00008)
 
 As we continue this line of work, we intend to incorporate new algorithms in
 this package, and the list of papers will be updated accordingly (along with

--- a/docs/src/probablesafety.md
+++ b/docs/src/probablesafety.md
@@ -1,0 +1,13 @@
+# Probable Safety
+
+In the paper "Statistical Hypothesis Testing of Controller Implementations
+Under Timing Uncertainties," we developed a method for estimating the maximum
+deviation of a control system that may experience deadline misses.  This
+estimate is based on Jeffreys' Bayes factor hypothesis testing, and is
+probabilistically guaranteed.  The method is implemented in the
+[`estimate_deviation`](@ref) function.
+
+```@docs
+estimate_deviation
+maximum_deviation_random
+```

--- a/src/ControlTimingSafety.jl
+++ b/src/ControlTimingSafety.jl
@@ -13,4 +13,6 @@ export corners_from_bounds, merge_bounds
 export bounded_runs, bounded_runs_iter, deviation
 include("safety.jl")
 
+include("probablesafety.jl")
+
 end

--- a/src/ControlTimingSafety.jl
+++ b/src/ControlTimingSafety.jl
@@ -13,6 +13,7 @@ export corners_from_bounds, merge_bounds
 export bounded_runs, bounded_runs_iter, deviation
 include("safety.jl")
 
+export maximum_deviation_random, estimate_deviation
 include("probablesafety.jl")
 
 end

--- a/src/probablesafety.jl
+++ b/src/probablesafety.jl
@@ -1,0 +1,69 @@
+"""
+    maximum_deviation_random(a, sampler, z_0, samples; dims, estimate, nominal,
+                             nominal_trajectory)
+
+Calculate `samples` random behaviors using `sampler`, and the corresponding trajectories of
+the [`Automaton`](@ref) `a` from the initial state `z_0`.  Return the maximum deviation
+from a nominal trajectory.  The parameters `dims`, `nominal`, and `nominal_trajectory` are
+as in [`deviation`](@ref).  If `estimate` is specified, stop early if this deviation
+estimate is exceeded, returning the exceeding deviation.
+"""
+Base.@propagate_inbounds function maximum_deviation_random(a::Automaton,
+        sampler::RealTimeScheduling.SamplerUniformMissRow, samples::Int64, z_0;
+        dims=axes(z_0,1),
+        estimate::Union{Float64, Nothing}=nothing,
+        nominal::AbstractVector{Int64}=ones(Int64,sampler.H),
+        nominal_trajectory::Union{AbstractArray{Float64}, Nothing}=nothing)
+    @boundscheck length(nominal) == sampler.H || throw(DimensionMismatch("nominal must have length sampler.H"))
+    @boundscheck dims ⊆ axes(z_0, 1) || throw(ArgumentError("All entries of dims must be valid indices to the first dimension of z_0"))
+    @boundscheck nominal_trajectory === nothing || size(nominal_trajectory) == (size(z_0,1), sampler.H+1) || throw(DimensionMismatch("nominal_trajectory must have size (size(z_0,1), sampler.H+1)"))
+    schedules = rand(sampler, samples)
+    if nominal_trajectory === nothing
+        nominal_trajectory = evol(a, z_0, nominal)
+    end
+    maxdev = 0.0
+    for s in schedules
+        ev = evol(a, z_0, 2 .- s)
+        dist = deviation(a, z_0, ev, nominal_trajectory=nominal_trajectory, dims=dims)
+        maxdev = maximum([dist; maxdev])
+        if estimate !== nothing && maxdev > estimate
+            return maxdev
+        end
+    end
+    maxdev
+end
+
+"""
+    estimate_deviation(a, sampler, z_0, c, B; dims, nominal, nominal_trajectory)
+
+Estimate the deviation possible in the [`Automaton`](@ref) `a`, using `sampler` to generate
+random behaviors.  The initial state is given as `z_0`.  `c` specifies the confidence with
+which the returned value is asserted to be an upper bound, and `B` is the Bayes factor used
+in hypothesis testing.  The parameters `dims`, `nominal`, and `nominal_trajectory` are as
+in [`deviation`](@ref).
+
+For more information, see Bineet Ghosh et al., "Statistical Hypothesis Testing of Controller
+Implementations Under Timing Uncertainties," RTCSA 2022. 
+DOI: [10.1109/RTCSA55878.2022.00008](https://doi.org/10.1109/RTCSA55878.2022.00008)
+"""
+Base.@propagate_inbounds function estimate_deviation(a::Automaton,
+        sampler::RealTimeScheduling.SamplerUniformMissRow, z_0, c::Float64, B::Float64;
+        dims=axes(z_0,1),
+        nominal::AbstractVector{Int64}=ones(Int64,sampler.H),
+        nominal_trajectory::Union{AbstractArray{Float64}, Nothing}=nothing)
+    @boundscheck length(nominal) == sampler.H || throw(DimensionMismatch("nominal must have length sampler.H"))
+    @boundscheck dims ⊆ axes(z_0, 1) || throw(ArgumentError("All entries of dims must be valid indices to the first dimension of z_0"))
+    @boundscheck nominal_trajectory === nothing || size(nominal_trajectory) == (size(z_0,1), sampler.H+1) || throw(DimensionMismatch("nominal_trajectory must have size (size(z_0,1), sampler.H+1)"))
+    K = ceil(Int64, -log(c, B+1))
+    estimate = maximum_deviation_random(a, sampler, 20, z_0, dims=dims)
+    while true
+        max_seen = maximum_deviation_random(a, sampler, K, z_0, dims=dims,
+                                            estimate=estimate, nominal=nominal,
+                                            nominal_trajectory=nominal_trajectory)
+        if max_seen <= estimate
+            break
+        end
+        estimate = max_seen
+    end
+    estimate
+end

--- a/src/safety.jl
+++ b/src/safety.jl
@@ -44,12 +44,12 @@ function merge_bounds(b)
 end
 
 """
-    bounded_runs(a::Automaton, bounds, n)
+    bounded_runs(a::Automaton, z0, n)
 
 Compute reachable sets for `n` time steps for the given [`Automaton`](@ref) `a`, starting
-from the initial set given by `bounds`.
+from the initial set given by `z0`.
 
-`bounds` must be an `a.nz`-element vector, or an `a.nz`×`2` matrix whose first and second
+`z0` must be an `a.nz`-element vector, or an `a.nz`×`2` matrix whose first and second
 columns are the minimum and maximum along each dimension, respectively.
 
 Returns `(bounds, locs)`, where `bounds` is an `nactions(a)^n`×`n+1`×`a.nz`×`2`
@@ -62,8 +62,8 @@ compute reachable sets for longer time horizons.  Typically one will call
 [`deviation`](@ref) on the results of this function to determine deviation from a nominal
 trajectory.
 """
-function bounded_runs(a::Automaton, bounds::AbstractVecOrMat, n::Integer)
-    corners = corners_from_bounds(bounds)
+function bounded_runs(a::Automaton, z0::AbstractVecOrMat, n::Integer)
+    corners = corners_from_bounds(z0)
 
     # Stack
     z = Array{Float64}(undef, n+1, size(corners)...)
@@ -107,24 +107,24 @@ function bounded_runs(a::Automaton, bounds::AbstractVecOrMat, n::Integer)
 end
 
 """
-    bounded_runs_iter(a, bounds, n, t)
+    bounded_runs_iter(a, z0, n, t)
 
-Iterate [`bounded_runs`](@ref)`(a, bounds, n)` for `t` iterations, returning the reachable
+Iterate [`bounded_runs`](@ref)`(a, z0, n)` for `t` iterations, returning the reachable
 set at each of the `n`×`t+1` time steps.
 
 See also [`deviation`](@ref), which can be called with the result of this function to find
 the deviation from a nominal trajectory.
 """
-function bounded_runs_iter(a::Automaton, bounds::AbstractVecOrMat, n::Integer, t::Integer)
+function bounded_runs_iter(a::Automaton, z0::AbstractVecOrMat, n::Integer, t::Integer)
     # Dimensions: time, augmented state, min/max
     all_bounds = Array{Float64}(undef, n*(t+1)+1, a.nz, 2)
-    if isa(bounds, AbstractVector)
-        all_bounds[1,:,:] = [bounds bounds]
+    if isa(z0, AbstractVector)
+        all_bounds[1,:,:] = [z0 z0]
     else
-        all_bounds[1,:,:] = bounds
+        all_bounds[1,:,:] = z0
     end
 
-    bounds = bounded_runs(a, bounds, n)
+    bounds = bounded_runs(a, z0, n)
     all_bounds[1:n+1,:,:] = merge_bounds(bounds)[:,:,1:end]
 
     # Dimensions: initial location, final location, time, augmented state, min/max
@@ -146,10 +146,10 @@ function bounded_runs_iter(a::Automaton, bounds::AbstractVecOrMat, n::Integer, t
 end
 
 """
-    deviation(a, bounds, reachable; dims=[all], metric=Euclidean(), nominal=[1,1,...])
+    deviation(a, z0, reachable; dims=[all], metric=Euclidean(), nominal=[1,1,...])
 
 Compute the deviation from the `nominal` behavior (default: all `1`) that is possible for
-the given [`Automaton`](@ref) `a`, starting from the set of initial states `bounds`, within
+the given [`Automaton`](@ref) `a`, starting from the set of initial states `z0`, within
 the `reachable` sets.  The deviation is computed using the specified `metric` from the
 [Distances.jl](https://www.juliapackages.com/p/distances) package.  If `dims` is specified,
 the deviation is computed for these dimensions only; otherwise, all dimensions are used.
@@ -159,12 +159,12 @@ matrix with dimensions (state, time), e.g. from [`evol`](@ref).
 See also [`bounded_runs`](@ref) and [`bounded_runs_iter`](@ref), which can be used to
 compute `reachable`.
 """
-function deviation(a::Automaton, bounds::AbstractVecOrMat{Float64},
+function deviation(a::Automaton, z0::AbstractVecOrMat{Float64},
                    reachable::Union{AbstractArray{Float64,2}, AbstractArray{Float64,3}};
-                   dims=axes(bounds,1), metric::PreMetric=Euclidean(),
+                   dims=axes(z0,1), metric::PreMetric=Euclidean(),
                    nominal=ones(Int64,size(reachable,1)-1))
     @boundscheck length(nominal) == size(reachable, 1) - 1 || throw(DimensionMismatch("nominal must have length size(reachable, 1) - 1"))
-    @boundscheck dims ⊆ axes(bounds, 1) || throw(ArgumentError("All entries of dims must be valid indices to the first dimension of bounds"))
+    @boundscheck dims ⊆ axes(z0, 1) || throw(ArgumentError("All entries of dims must be valid indices to the first dimension of z0"))
 
     # Dimensions: state variables, points, time
     if reachable isa AbstractArray{Float64, 3}
@@ -174,13 +174,13 @@ function deviation(a::Automaton, bounds::AbstractVecOrMat{Float64},
     end
 
     # Dimensions: state variables, points, time
-    if bounds isa AbstractVector{Float64}
+    if z0 isa AbstractVector{Float64}
         # XXX Not the most memory-efficient solution, but keeps us from having
         # to maintain two nearly-identical methods of the function.
-        bounds = [bounds bounds]
+        z0 = [z0 z0]
     end
-    ev = Array{Float64}(undef, length(dims), 2^size(bounds,1), size(reachable, 1))
-    corners = corners_from_bounds(bounds, dims=axes(bounds,1))
+    ev = Array{Float64}(undef, length(dims), 2^size(z0,1), size(reachable, 1))
+    corners = corners_from_bounds(z0, dims=axes(z0,1))
     for (i, c) in enumerate(eachcol(corners))
         e = evol(a, c, nominal)
         ev[:,i,:] = e'[dims,:]


### PR DESCRIPTION
This commit adds a few new functions to estimate the maximum deviation that an `Automaton` may experience using Jeffreys' Bayes factor hypothesis testing.  This is the method from ["Statistical Hypothesis Testing of Controller Implementations Under Timing Uncertainties"](https://doi.org/10.1109/RTCSA55878.2022.00008).  For now, we only support a single initial point, but support for an initial *set* will be forthcoming.

Closes #7.