### PR TITLE
Use threads in bounded_runs_iter

### DIFF
--- a/src/safety.jl
+++ b/src/safety.jl
@@ -178,7 +178,7 @@ function bounded_runs_iter(a::Automaton, z_0::AbstractVecOrMat, n::Integer, t::I
     new_bounds = Array{Float64}(undef, nlocations(a), nlocations(a), n+1, a.nz, 2)
     for i in 1:t
         # Simulate each box from previous iteration
-        for i in a.L
+        Threads.@threads for i in a.L
             new_bounds[i,:,:,:,:] = bounded_runs(A[i], bounds[i,end,:,:], n)
         end
         # Merge resulting boxes from these simulations


### PR DESCRIPTION
This PR implements the easy part of #3 by parallelizing the many calls to `bounded_runs` in the `bounded_runs_iter` function.  Since these calls are completely independent, the only change is to trivially run the loop in parallel, giving a hearty speedup.